### PR TITLE
Enable item reordering and inline deletion

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AVD Policy Hierarchy Prototype</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="app">
+    <aside class="panel info-panel">
+      <header>
+        <h1>Hierarchy Builder Guide</h1>
+        <p>Plan and visualize how Azure Virtual Desktop policies, scripts, registry entries, and applications are prioritized. Drag items into the workspace to craft the execution order your host pools will follow.</p>
+      </header>
+      <section class="tips">
+        <h2>How to use</h2>
+        <ol>
+          <li>Drag an item or group from the palette into the workspace.</li>
+          <li>Drop items on top of groups to nest them.</li>
+          <li>Reorder by dragging items between groups and levels.</li>
+          <li>Drop unwanted items onto the trash can to delete them.</li>
+        </ol>
+      </section>
+      <section class="counts">
+        <h2>Workspace summary</h2>
+        <ul>
+          <li><span class="count" data-count="policies">0</span> Policies</li>
+          <li><span class="count" data-count="scripts">0</span> Scripts</li>
+          <li><span class="count" data-count="registry">0</span> Registry entries</li>
+          <li><span class="count" data-count="applications">0</span> Applications</li>
+          <li><span class="count" data-count="groups">0</span> Groups</li>
+        </ul>
+      </section>
+      <section class="status" aria-live="polite">
+        <h2>Status</h2>
+        <p class="status-message" data-tone="info">Start arranging your hierarchy.</p>
+      </section>
+    </aside>
+
+    <main class="workspace">
+      <header class="workspace-header">
+        <div>
+          <h2>Execution hierarchy</h2>
+          <p>Drag items here to model the runtime order. Groups execute from top to bottom, then through nested children.</p>
+        </div>
+        <div id="trash" class="trash" data-dropzone="trash" aria-label="Trash bin" title="Drop here to delete">
+          <span class="icon">🗑️</span>
+          <span class="label">Trash</span>
+        </div>
+      </header>
+      <section class="hierarchy">
+        <ul id="hierarchy-root" class="node-list" data-dropzone="root" data-parent-id="root" aria-label="Hierarchy root">
+          <li class="placeholder">Drop items here to begin building your hierarchy.</li>
+        </ul>
+      </section>
+    </main>
+
+    <aside class="panel palette">
+      <header>
+        <h2>Item palette</h2>
+        <p>Drag any item into the hierarchy. Items from the palette create new copies each time.</p>
+      </header>
+      <section class="palette-section">
+        <h3>Single items</h3>
+        <ul class="palette-items">
+          <li class="palette-item kind-policy" draggable="true" data-template="policy">
+            <span class="icon">🛡️</span>
+            <div>
+              <strong>Policy</strong>
+              <p>Enforce configuration with WVD policies.</p>
+            </div>
+          </li>
+          <li class="palette-item kind-script" draggable="true" data-template="script">
+            <span class="icon">📜</span>
+            <div>
+              <strong>Script</strong>
+              <p>Execute PowerShell automation or remediation steps.</p>
+            </div>
+          </li>
+          <li class="palette-item kind-registry" draggable="true" data-template="registry">
+            <span class="icon">🧾</span>
+            <div>
+              <strong>Registry entry</strong>
+              <p>Manage registry keys applied at session start.</p>
+            </div>
+          </li>
+          <li class="palette-item kind-application" draggable="true" data-template="application">
+            <span class="icon">📦</span>
+            <div>
+              <strong>Application</strong>
+              <p>Publish MSIX or Win32 applications to desktops.</p>
+            </div>
+          </li>
+        </ul>
+      </section>
+      <section class="palette-section">
+        <h3>Structure</h3>
+        <ul class="palette-items">
+          <li class="palette-item kind-group" draggable="true" data-template="group">
+            <span class="icon">📁</span>
+            <div>
+              <strong>Group</strong>
+              <p>Create a nested folder that can hold policies, scripts, apps, or additional groups.</p>
+            </div>
+          </li>
+        </ul>
+      </section>
+    </aside>
+  </div>
+
+  <template id="group-template">
+    <li class="node node-group" data-kind="group">
+      <div class="node-header" draggable="true">
+        <span class="icon">📁</span>
+        <span class="node-title" contenteditable="true" spellcheck="false">New Group</span>
+        <span class="badge" aria-label="Child count">0</span>
+        <button class="delete-button" type="button" aria-label="Delete group">✖</button>
+      </div>
+      <ul class="node-list" data-dropzone="group" aria-label="Group children"></ul>
+    </li>
+  </template>
+
+  <template id="item-template">
+    <li class="node" draggable="true">
+      <div class="node-header">
+        <span class="icon"></span>
+        <span class="node-title"></span>
+        <button class="delete-button" type="button" aria-label="Delete item">✖</button>
+      </div>
+    </li>
+  </template>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,331 @@
+const paletteItems = document.querySelectorAll('.palette-item');
+const hierarchyRoot = document.getElementById('hierarchy-root');
+const groupTemplate = document.getElementById('group-template');
+const itemTemplate = document.getElementById('item-template');
+const statusMessage = document.querySelector('.status-message');
+let idCounter = 1;
+
+const templateConfig = {
+  policy: {
+    label: () => `Policy ${idCounter}`,
+    icon: '🛡️',
+    kind: 'policy'
+  },
+  script: {
+    label: () => `Script ${idCounter}`,
+    icon: '📜',
+    kind: 'script'
+  },
+  registry: {
+    label: () => `Registry ${idCounter}`,
+    icon: '🧾',
+    kind: 'registry'
+  },
+  application: {
+    label: () => `Application ${idCounter}`,
+    icon: '📦',
+    kind: 'application'
+  },
+  group: {
+    label: () => `Group ${idCounter}`,
+    icon: '📁',
+    kind: 'group'
+  }
+};
+
+function showStatus(message, tone = 'info') {
+  statusMessage.textContent = message;
+  statusMessage.dataset.tone = tone;
+}
+
+function updateCounts() {
+  const counts = {
+    policies: document.querySelectorAll('.node[data-kind="policy"]').length,
+    scripts: document.querySelectorAll('.node[data-kind="script"]').length,
+    registry: document.querySelectorAll('.node[data-kind="registry"]').length,
+    applications: document.querySelectorAll('.node[data-kind="application"]').length,
+    groups: document.querySelectorAll('.node[data-kind="group"]').length
+  };
+
+  Object.entries(counts).forEach(([key, value]) => {
+    const target = document.querySelector(`[data-count="${key}"]`);
+    if (target) {
+      target.textContent = value;
+    }
+  });
+
+  const placeholder = hierarchyRoot.querySelector('.placeholder');
+  if (placeholder) {
+    const hasNodes = hierarchyRoot.querySelectorAll('.node').length > 0;
+    placeholder.style.display = hasNodes ? 'none' : '';
+  }
+}
+
+function registerNode(node) {
+  const header = node.querySelector('.node-header');
+  header.addEventListener('dragstart', handleDragStart);
+  header.addEventListener('dragend', handleDragEnd);
+  header.setAttribute('draggable', 'true');
+
+  const deleteButton = node.querySelector('.delete-button');
+  if (deleteButton) {
+    deleteButton.addEventListener('mousedown', (event) => event.stopPropagation());
+    deleteButton.addEventListener('click', (event) => {
+      event.stopPropagation();
+      deleteNode(node);
+    });
+  }
+
+  if (node.dataset.kind === 'group') {
+    const dropZone = node.querySelector('[data-dropzone="group"]');
+    dropZone.dataset.parentId = node.dataset.id;
+    makeDroppable(dropZone);
+    node.classList.add('node-group');
+    header.addEventListener('dblclick', () => {
+      node.classList.toggle('collapsed');
+    });
+    node.querySelector('.node-title').addEventListener('blur', () => updateGroupState(node));
+    node.querySelector('.node-title').addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        event.currentTarget.blur();
+      }
+    });
+    updateGroupState(node);
+  }
+}
+
+function deleteNode(node) {
+  const parent = node.parentElement;
+  node.remove();
+  const parentGroup = parent && parent.closest('.node-group');
+  if (parentGroup) updateGroupState(parentGroup);
+  updateCounts();
+  showStatus('Item deleted.', 'success');
+}
+
+function updateGroupState(groupNode) {
+  const badge = groupNode.querySelector('.badge');
+  const childList = groupNode.querySelector('.node-list');
+  const childCount = childList ? childList.querySelectorAll(':scope > .node').length : 0;
+  if (badge) {
+    badge.textContent = childCount;
+  }
+  groupNode.classList.toggle('empty', childCount === 0);
+}
+
+function createGroup(label) {
+  const fragment = groupTemplate.content.cloneNode(true);
+  const node = fragment.querySelector('.node');
+  const title = node.querySelector('.node-title');
+  node.dataset.id = `node-${idCounter++}`;
+  title.textContent = label;
+  registerNode(node);
+  return node;
+}
+
+function createItem(kind, label, icon) {
+  const fragment = itemTemplate.content.cloneNode(true);
+  const node = fragment.querySelector('.node');
+  node.dataset.id = `node-${idCounter++}`;
+  node.dataset.kind = kind;
+  node.classList.add(`kind-${kind}`);
+  node.querySelector('.icon').textContent = icon;
+  node.querySelector('.node-title').textContent = label;
+  registerNode(node);
+  return node;
+}
+
+function handleDragStart(event) {
+  const node = event.currentTarget.closest('.node');
+  if (!node) return;
+  node.classList.add('dragging');
+  event.dataTransfer.effectAllowed = 'move';
+  event.dataTransfer.setData(
+    'application/json',
+    JSON.stringify({ action: 'move', id: node.dataset.id })
+  );
+}
+
+function handleDragEnd(event) {
+  const node = event.currentTarget.closest('.node');
+  if (node) {
+    node.classList.remove('dragging');
+  }
+}
+
+function preventCircularMove(node, dropZone) {
+  if (!node || !dropZone) return false;
+  const isInsideNode = !!dropZone.closest(`[data-id="${node.dataset.id}"]`);
+  if (!isInsideNode) return false;
+  if (dropZone.dataset.parentId === node.dataset.id) return false;
+  return true;
+}
+
+function moveNode(node, dropZone, referenceNode) {
+  if (!node) return;
+  const dropList = dropZone.matches('.node-list') ? dropZone : dropZone.querySelector('.node-list');
+  if (!dropList) return;
+
+  if (preventCircularMove(node, dropZone)) {
+    showStatus('Cannot move a group inside one of its descendants.', 'warning');
+    return;
+  }
+
+  const currentParent = node.parentElement;
+  if (referenceNode) {
+    dropList.insertBefore(node, referenceNode);
+  } else {
+    dropList.appendChild(node);
+  }
+
+  const previousGroup = currentParent && currentParent.closest('.node-group');
+  const newGroup = dropList.closest('.node-group');
+  if (previousGroup) updateGroupState(previousGroup);
+  if (newGroup) updateGroupState(newGroup);
+  updateCounts();
+  showStatus('Item moved.', 'success');
+}
+
+function addNodeFromTemplate(templateName, dropZone, referenceNode) {
+  const config = templateConfig[templateName];
+  if (!config) return;
+  let node;
+  if (templateName === 'group') {
+    node = createGroup(config.label());
+    node.dataset.kind = 'group';
+    node.classList.add('kind-group');
+  } else {
+    node = createItem(config.kind, config.label(), config.icon);
+  }
+
+  const list = dropZone.matches('.node-list') ? dropZone : dropZone.querySelector('.node-list');
+  if (!list) return;
+  if (referenceNode) {
+    list.insertBefore(node, referenceNode);
+  } else {
+    list.appendChild(node);
+  }
+  const parentGroup = list.closest('.node-group');
+  if (parentGroup) updateGroupState(parentGroup);
+  updateCounts();
+  showStatus(`${config.kind === 'group' ? 'Group' : config.kind.charAt(0).toUpperCase() + config.kind.slice(1)} added to the hierarchy.`, 'success');
+}
+
+function clearDropIndicators(list) {
+  if (!list) return;
+  list.classList.remove('drop-at-end');
+  list.querySelectorAll(':scope > .node.drop-before').forEach((node) => node.classList.remove('drop-before'));
+}
+
+function getInsertionReference(list, clientY) {
+  if (!list) return null;
+  const nodes = [...list.querySelectorAll(':scope > .node:not(.dragging)')];
+  for (const node of nodes) {
+    const rect = node.getBoundingClientRect();
+    if (clientY < rect.top + rect.height / 2) {
+      return node;
+    }
+  }
+  return null;
+}
+
+function makeDroppable(zone) {
+  zone.addEventListener('dragover', (event) => {
+    event.preventDefault();
+    zone.classList.add('droppable-hover');
+    if (zone.dataset.dropzone === 'trash') {
+      zone.classList.add('active');
+    }
+    const dropList = zone.matches('.node-list') ? zone : zone.querySelector('.node-list');
+    if (dropList) {
+      clearDropIndicators(dropList);
+      const referenceNode = getInsertionReference(dropList, event.clientY);
+      if (referenceNode) {
+        referenceNode.classList.add('drop-before');
+      } else if (dropList.querySelector(':scope > .node')) {
+        dropList.classList.add('drop-at-end');
+      }
+    }
+    const allowed = event.dataTransfer.effectAllowed;
+    if (allowed && allowed.includes('copy') && zone.dataset.dropzone !== 'trash') {
+      event.dataTransfer.dropEffect = 'copy';
+    } else {
+      event.dataTransfer.dropEffect = 'move';
+    }
+  });
+
+  zone.addEventListener('dragleave', (event) => {
+    zone.classList.remove('droppable-hover');
+    if (zone.dataset.dropzone === 'trash') {
+      zone.classList.remove('active');
+    }
+    const dropList = zone.matches('.node-list') ? zone : zone.querySelector('.node-list');
+    if (dropList && (!event.relatedTarget || !zone.contains(event.relatedTarget))) {
+      clearDropIndicators(dropList);
+    }
+  });
+
+  zone.addEventListener('drop', (event) => {
+    event.preventDefault();
+    zone.classList.remove('droppable-hover');
+    if (zone.dataset.dropzone === 'trash') {
+      zone.classList.remove('active');
+    }
+    const dropList = zone.matches('.node-list') ? zone : zone.querySelector('.node-list');
+    const referenceNode = dropList ? getInsertionReference(dropList, event.clientY) : null;
+    if (dropList) {
+      clearDropIndicators(dropList);
+    }
+    const dataJSON = event.dataTransfer.getData('application/json');
+    if (!dataJSON) return;
+
+    let data;
+    try {
+      data = JSON.parse(dataJSON);
+    } catch (error) {
+      console.error('Invalid drop payload', error);
+      return;
+    }
+
+    if (zone.dataset.dropzone === 'trash') {
+      if (data.action === 'move') {
+        const node = document.querySelector(`[data-id="${data.id}"]`);
+        if (node) {
+          deleteNode(node);
+        }
+      }
+      return;
+    }
+
+    if (data.action === 'create') {
+      addNodeFromTemplate(data.template, zone, referenceNode);
+    } else if (data.action === 'move') {
+      const node = document.querySelector(`[data-id="${data.id}"]`);
+      if (!node) return;
+      moveNode(node, zone, referenceNode);
+    }
+  });
+}
+
+function makePaletteDraggable(item) {
+  item.addEventListener('dragstart', (event) => {
+    const template = item.dataset.template;
+    if (!template) return;
+    event.dataTransfer.effectAllowed = 'copy';
+    event.dataTransfer.setData('application/json', JSON.stringify({ action: 'create', template }));
+    item.classList.add('dragging');
+  });
+
+  item.addEventListener('dragend', () => {
+    item.classList.remove('dragging');
+  });
+}
+
+function initialize() {
+  paletteItems.forEach(makePaletteDraggable);
+  document.querySelectorAll('[data-dropzone]').forEach(makeDroppable);
+  updateCounts();
+}
+
+initialize();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,403 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --bg: #f5f7fb;
+  --panel-bg: #ffffff;
+  --accent: #2563eb;
+  --accent-soft: rgba(37, 99, 235, 0.12);
+  --border: #e2e8f0;
+  --text: #1f2937;
+  --subtle-text: #4b5563;
+  --policy: #2563eb;
+  --script: #7c3aed;
+  --registry: #0f766e;
+  --application: #b91c1c;
+  --group: #111827;
+  --shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.app {
+  display: grid;
+  grid-template-columns: minmax(260px, 1.1fr) minmax(400px, 1.3fr) minmax(280px, 1fr);
+  gap: 1.5rem;
+  padding: 2rem;
+}
+
+.panel,
+.workspace {
+  background: var(--panel-bg);
+  border-radius: 18px;
+  padding: 1.75rem;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel h1,
+.panel h2,
+.panel h3,
+.workspace h2 {
+  margin: 0 0 0.75rem;
+  font-weight: 600;
+}
+
+.panel p,
+.panel li,
+.workspace p {
+  color: var(--subtle-text);
+  line-height: 1.5;
+}
+
+.info-panel ol {
+  padding-left: 1.1rem;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.counts ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.counts .count {
+  font-weight: 600;
+  color: var(--accent);
+  display: inline-block;
+  width: 2ch;
+}
+
+.status {
+  margin-top: auto;
+}
+
+.status h2 {
+  font-size: 1rem;
+}
+
+.status-message {
+  background: var(--accent-soft);
+  color: var(--accent);
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  margin: 0;
+  font-weight: 500;
+}
+
+.status-message[data-tone="warning"] {
+  background: #fef3c7;
+  color: #b45309;
+}
+
+.status-message[data-tone="success"] {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.workspace {
+  position: relative;
+}
+
+.workspace-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.workspace-header p {
+  margin: 0;
+}
+
+.trash {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.65rem 0.9rem;
+  border-radius: 999px;
+  background: #fee2e2;
+  color: #b91c1c;
+  font-weight: 600;
+  cursor: grab;
+  border: 1px solid rgba(185, 28, 28, 0.2);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.trash.active {
+  background: #fca5a5;
+  transform: scale(1.04);
+  box-shadow: 0 12px 24px rgba(185, 28, 28, 0.25);
+}
+
+.hierarchy {
+  flex: 1;
+  overflow: auto;
+  padding: 0.5rem;
+  border-radius: 14px;
+  border: 1px dashed rgba(15, 23, 42, 0.12);
+  background: rgba(241, 245, 249, 0.6);
+}
+
+.node-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.node-list[data-dropzone] {
+  min-height: 3rem;
+}
+
+.node-list .placeholder {
+  color: var(--subtle-text);
+  font-style: italic;
+  text-align: center;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px dashed rgba(148, 163, 184, 0.8);
+}
+
+.node {
+  border-radius: 14px;
+  background: #ffffff;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
+  position: relative;
+}
+
+.node.dragging {
+  opacity: 0.4;
+  box-shadow: none;
+}
+
+.node-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.9rem 1rem;
+  cursor: grab;
+}
+
+.delete-button {
+  border: none;
+  background: transparent;
+  color: var(--subtle-text);
+  border-radius: 8px;
+  padding: 0.25rem 0.35rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.delete-button:hover,
+.delete-button:focus-visible {
+  background: rgba(248, 113, 113, 0.16);
+  color: #b91c1c;
+  outline: none;
+}
+
+.node-header .icon {
+  font-size: 1.1rem;
+}
+
+.node-title {
+  font-weight: 600;
+  flex: 1;
+}
+
+.node-group .node-title {
+  outline: none;
+}
+
+.node-group .badge {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--accent);
+  padding: 0.3rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.node-group .node-list {
+  margin: 0 1rem 1rem 3rem;
+  padding: 0.75rem 0.5rem 0.5rem;
+  background: rgba(37, 99, 235, 0.05);
+  border-radius: 12px;
+  border: 1px dashed rgba(37, 99, 235, 0.35);
+}
+
+.node-list {
+  position: relative;
+}
+
+.node.drop-before::before {
+  content: '';
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  top: -0.1rem;
+  height: 3px;
+  background: var(--accent);
+  border-radius: 999px;
+}
+
+.node-list.drop-at-end::after {
+  content: '';
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: -0.1rem;
+  height: 3px;
+  background: var(--accent);
+  border-radius: 999px;
+}
+
+.node-group.empty .node-list::before {
+  content: 'Drop items here';
+  display: block;
+  color: rgba(37, 99, 235, 0.6);
+  font-size: 0.85rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.node-group.empty .node-list {
+  min-height: 2.5rem;
+}
+
+.node-group.collapsed .node-list {
+  display: none;
+}
+
+.node-group.collapsed .node-header::after {
+  content: '›';
+  font-weight: 700;
+  transform: rotate(90deg);
+  margin-left: 0.5rem;
+  color: rgba(15, 23, 42, 0.4);
+}
+
+.node-group .node-header::after {
+  content: '⌄';
+  font-weight: 700;
+  margin-left: 0.5rem;
+  color: rgba(15, 23, 42, 0.35);
+}
+
+.kind-policy .node-header,
+.palette-item.kind-policy {
+  border-left: 4px solid var(--policy);
+}
+
+.kind-script .node-header,
+.palette-item.kind-script {
+  border-left: 4px solid var(--script);
+}
+
+.kind-registry .node-header,
+.palette-item.kind-registry {
+  border-left: 4px solid var(--registry);
+}
+
+.kind-application .node-header,
+.palette-item.kind-application {
+  border-left: 4px solid var(--application);
+}
+
+.kind-group .node-header,
+.node-group .node-header,
+.palette-item.kind-group {
+  border-left: 4px solid var(--group);
+}
+
+.palette {
+  gap: 1rem;
+}
+
+.palette-section {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.palette-items {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.palette-item {
+  background: rgba(248, 250, 252, 0.9);
+  border-radius: 16px;
+  padding: 0.8rem 1rem;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.8rem;
+  cursor: grab;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
+}
+
+.palette-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 20px rgba(15, 23, 42, 0.12);
+}
+
+.palette-item strong {
+  display: block;
+  margin-bottom: 0.1rem;
+}
+
+.palette-item p {
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+[data-dropzone].droppable-hover {
+  outline: 3px solid var(--accent);
+  outline-offset: 2px;
+}
+
+[data-dropzone="trash"].droppable-hover {
+  outline: none;
+}
+
+@media (max-width: 1200px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+
+  .panel,
+  .workspace {
+    box-shadow: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .app {
+    padding: 1.25rem;
+  }
+
+  .node-group .node-list {
+    margin-left: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- allow dropzones to calculate insertion points so new or moved items can be placed above or below existing entries
- add inline delete controls to hierarchy nodes and centralize removal logic reused by the trash dropzone
- style the new delete affordances and insertion indicators to clarify ordering feedback

## Testing
- Not run (static prototype)

------
https://chatgpt.com/codex/tasks/task_e_690090f57b648332b97494d5ffa4212a